### PR TITLE
NuGet Publishing Workflow

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,52 @@
+# GitHub Actions workflow to publish NuGet package using trusted publishing
+name: Publish NuGet Package
+
+on:
+  workflow_dispatch:  # Manual triggering only
+
+# Define the job that will run when the workflow is triggered
+jobs:
+  publish-nuget:
+    # Run the job on the latest Ubuntu virtual machine
+    runs-on: ubuntu-latest
+    
+    # Set permissions required for trusted publishing
+    # id-token: write enables GitHub OIDC token issuance for trusted publishing
+    permissions:
+      id-token: write  # Enable GitHub OIDC token issuance for trusted publishing
+    
+    # Define the steps that will be executed in sequence
+    steps:
+    # Step 1: Check out the repository code from the main branch
+    - uses: actions/checkout@v4  # Get the latest code from the repository
+      with:
+        ref: main  # Explicitly checkout the main branch
+
+    # Step 2: Setup .NET SDK
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4  # Install the .NET SDK
+      with:
+        dotnet-version: 9.0.x  # Use the latest .NET 9.0 version
+
+    # Step 3: Restore NuGet packages
+    - name: Restore dependencies
+      run: dotnet restore  # Download and restore all project dependencies
+
+    # Step 4: Build the project in Release configuration
+    - name: Build
+      run: dotnet build --no-restore --configuration Release  # Compile the code in Release mode
+
+    # Step 5: Create the NuGet package
+    - name: Pack NuGet package
+      run: dotnet pack InzSeeder.Core/InzSeeder.Core.csproj --no-build --configuration Release --output ./nupkg  # Package the library into a .nupkg file
+
+    # Step 6: Login to NuGet using trusted publishing
+    - name: NuGet login (trusted publishing)
+      uses: NuGet/login@v1  # Use the official NuGet login action for trusted publishing
+      id: login  # Set an ID so we can reference the output later
+      with:
+        user: ${{ secrets.NUGET_USERNAME }}  # Your NuGet.org username (stored as a GitHub secret)
+
+    # Step 7: Publish the package to NuGet.org
+    - name: Publish to NuGet.org
+      run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate  # Push the package to NuGet.org using the temporary API key

--- a/Documentation/NuGet-Publishing-Guide.md
+++ b/Documentation/NuGet-Publishing-Guide.md
@@ -1,0 +1,85 @@
+# Publishing NuGet Package
+
+This document explains how to publish the InzSeeder.Core library as a NuGet package using the GitHub Actions workflow with trusted publishing. For safety, the workflow is configured to be manually triggered only.
+
+## GitHub Actions Workflow
+
+The repository includes a GitHub Actions workflow that packs and publishes the NuGet package when manually triggered. The workflow uses NuGet's trusted publishing feature, which eliminates the need for long-lived API keys.
+
+### Workflow Triggers
+
+The workflow is triggered only manually through the GitHub Actions interface for safety:
+1. Go to the "Actions" tab in your repository
+2. Select "Publish NuGet Package" workflow
+3. Click "Run workflow" and confirm
+
+### Workflow Steps
+
+1. **Setup**: The workflow sets up the .NET environment (version 9.0.x)
+2. **Restore**: Restores all project dependencies
+3. **Build**: Builds the solution in Release configuration
+4. **Pack**: Creates the NuGet package from the InzSeeder.Core project
+5. **Login**: Uses trusted publishing to obtain a temporary API key
+6. **Publish**: Publishes the package to NuGet.org using the temporary API key
+
+## Publishing a New Version
+
+To publish a new version of the NuGet package:
+
+1. Update the version in `InzSeeder.Core/InzSeeder.Core.csproj`:
+   ```xml
+   <PropertyGroup>
+     <!-- ... other properties ... -->
+     <PackageVersion>2.0.0</PackageVersion>
+     <!-- ... other properties ... -->
+   </PropertyGroup>
+   ```
+
+2. Commit and push your changes:
+   ```bash
+   git add InzSeeder.Core/InzSeeder.Core.csproj
+   git commit -m "Bump version to 2.0.0"
+   git push
+   ```
+
+3. Trigger the workflow manually:
+   - Go to the "Actions" tab in your repository
+   - Select "Publish NuGet Package" workflow
+   - Click "Run workflow" and confirm
+
+## Trusted Publishing Setup
+
+Instead of using long-lived API keys, this workflow uses NuGet's trusted publishing feature. To set this up:
+
+1. Create a trusted publishing policy on NuGet.org:
+   - Log into NuGet.org
+   - Click your username and select "Trusted Publishing"
+   - Add a new trusted publishing policy with:
+     * Repository Owner: Your GitHub username or organization
+     * Repository name: InzSeeder
+     * Workflow file name: publish-nuget.yml
+     * Environment: (leave blank unless using GitHub Environments)
+
+2. Add your NuGet username as a GitHub secret:
+   - Go to Settings > Secrets and variables > Actions
+   - Click "New repository secret"
+   - Name it `NUGET_USERNAME`
+   - Enter your NuGet.org username as the value
+
+With trusted publishing, no long-lived API keys are stored in your repository. Instead, GitHub Actions securely exchanges an OIDC token with NuGet.org to obtain a temporary API key for each publish operation.
+
+## Local Publishing
+
+To pack and publish locally, you'll still need a traditional API key:
+
+1. Generate an API key at https://www.nuget.org/account/apikeys
+2. Pack the NuGet package:
+   ```bash
+   cd InzSeeder.Core
+   dotnet pack --configuration Release
+   ```
+
+3. Publish the package:
+   ```bash
+   dotnet nuget push bin/Release/Inz.Seeder.2.0.0.nupkg --api-key YOUR_API_KEY --source https://api.nuget.org/v3/index.json
+   ```

--- a/InzSeeder.Core/InzSeeder.Core.csproj
+++ b/InzSeeder.Core/InzSeeder.Core.csproj
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Inz.Seeder</PackageId>
-        <PackageVersion>1.0.0</PackageVersion>
+        <PackageVersion>2.0.1</PackageVersion>
         <Authors>Abdellah Addoun</Authors>
         <Company>Inz Softwares</Company>
         <Product>Inz Seeder</Product>


### PR DESCRIPTION
- Introduces a GitHub Actions workflow to automate publishing the Inz.Seeder package to NuGet.
- Adds a comprehensive guide (NuGet-Publishing-Guide.md) on how to manually publish the package.
- Bumps the package version to 2.0.1 in preparation for the new release.