### PR TITLE
Fix - Publish Package Action

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -17,36 +17,36 @@ jobs:
     
     # Define the steps that will be executed in sequence
     steps:
-    # Step 1: Check out the repository code from the main branch
-    - uses: actions/checkout@v4  # Get the latest code from the repository
-      with:
-        ref: main  # Explicitly checkout the main branch
-
-    # Step 2: Setup .NET SDK
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4  # Install the .NET SDK
-      with:
-        dotnet-version: 9.0.x  # Use the latest .NET 9.0 version
-
-    # Step 3: Restore NuGet packages
-    - name: Restore dependencies
-      run: dotnet restore  # Download and restore all project dependencies
-
-    # Step 4: Build the project in Release configuration
-    - name: Build
-      run: dotnet build --no-restore --configuration Release  # Compile the code in Release mode
-
-    # Step 5: Create the NuGet package
-    - name: Pack NuGet package
-      run: dotnet pack InzSeeder.Core/InzSeeder.Core.csproj --no-build --configuration Release --output ./nupkg  # Package the library into a .nupkg file
-
-    # Step 6: Login to NuGet using trusted publishing
-    - name: NuGet login (trusted publishing)
-      uses: NuGet/login@v1  # Use the official NuGet login action for trusted publishing
-      id: login  # Set an ID so we can reference the output later
-      with:
-        user: ${{ secrets.NUGET_USERNAME }}  # Your NuGet.org username (stored as a GitHub secret)
-
-    # Step 7: Publish the package to NuGet.org
-    - name: Publish to NuGet.org
-      run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate  # Push the package to NuGet.org using the temporary API key
+      # Step 1: Check out the repository code from the main branch
+      - uses: actions/checkout@v4  # Get the latest code from the repository
+        with:
+          ref: main  # Explicitly checkout the main branch
+      
+      # Step 2: Setup .NET SDK
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4  # Install the .NET SDK
+        with:
+          dotnet-version: 9.0.x  # Use the latest .NET 9.0 version
+      
+      # Step 3: Restore NuGet packages
+      - name: Restore dependencies
+        run: dotnet restore  # Download and restore all project dependencies
+      
+      # Step 4: Build the project in Release configuration
+      - name: Build
+        run: dotnet build --no-restore --configuration Release  # Compile the code in Release mode
+      
+      # Step 5: Create the NuGet package
+      - name: Pack NuGet package
+        run: dotnet pack InzSeeder.Core/InzSeeder.Core.csproj --no-build --configuration Release --output ./nupkg  # Package the library into a .nupkg file
+      
+      # Step 6: Login to NuGet using trusted publishing
+      - name: NuGet login (trusted publishing)
+        uses: NuGet/login@v1  # Use the official NuGet login action for trusted publishing
+        id: login  # Set an ID so we can reference the output later
+        with:
+          user: ${{ secrets.NUGET_USERNAME }}  # Your NuGet.org username (stored as a GitHub secret)
+      
+      # Step 7: Publish the package to NuGet.org
+      - name: Publish to NuGet.org
+        run: dotnet nuget push artifacts/my-sdk.nupkg --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json

--- a/InzSeeder.Core/InzSeeder.Core.csproj
+++ b/InzSeeder.Core/InzSeeder.Core.csproj
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PackageId>Inz.Seeder</PackageId>
-        <PackageVersion>2.0.1</PackageVersion>
+        <PackageVersion>2.0.2</PackageVersion>
         <Authors>Abdellah Addoun</Authors>
         <Company>Inz Softwares</Company>
         <Product>Inz Seeder</Product>


### PR DESCRIPTION
Updates the NuGet publishing workflow by changing the path of the package to be published from './nupkg/*.nupkg' to 'artifacts/my-sdk.nupkg' and removing the '--skip-duplicate' flag.