### PR TITLE
InzSoftwares.NetSeeder

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -63,6 +63,6 @@ jobs:
       - name: Publish to NuGet.org
         run: |
           # Construct the package file name using the extracted version
-          PACKAGE_PATH="./nupkg/Inz.Seeder.${{ steps.version.outputs.version }}.nupkg"
+          PACKAGE_PATH="./nupkg/InzSoftwares.NetSeeder.${{ steps.version.outputs.version }}.nupkg"
           echo "Publishing package: $PACKAGE_PATH"
           dotnet nuget push "$PACKAGE_PATH" --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,8 +1,6 @@
 name: Run Tests
 
 on:
-  push:
-    branches: [ development ]
   pull_request:
     branches: [ "**" ]
 

--- a/InzSeeder.Core/InzSeeder.Core.csproj
+++ b/InzSeeder.Core/InzSeeder.Core.csproj
@@ -5,11 +5,15 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <PackageId>Inz.Seeder</PackageId>
-        <PackageVersion>2.0.2</PackageVersion>
+        <PackageId>InzSoftwares.NetSeeder</PackageId>
+        <PackageVersion>2.0.3</PackageVersion>
         <Authors>Abdellah Addoun</Authors>
         <Company>Inz Softwares</Company>
-        <Product>Inz Seeder</Product>
+        <Product>.NET Data Seeder</Product>
+        <RepositoryUrl>https://github.com/joeloudjinz/InzSeeder</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <Copyright>Copyright (c) Abdellah Addoun (joe-inz) 2025</Copyright>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <Description>
             A powerful and flexible data seeding library for .NET applications, designed to streamline the process of populating databases with test
             or initial data. It supports environment-specific data, dependency management between seeders, batch processing for large datasets,
@@ -36,6 +40,7 @@
     </PropertyGroup>
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="\"/>
+        <None Include="LICENSE" Pack="true" PackagePath="\"/>
     </ItemGroup>
-    
+
 </Project>

--- a/InzSeeder.Core/README.md
+++ b/InzSeeder.Core/README.md
@@ -1,6 +1,6 @@
-# InzSeeder
+# InzSoftwares.NetSeeder
 
-InzSeeder is a flexible, generic data seeding library for .NET applications that can be used to seed any database with initial data.
+A flexible, generic data seeding library for .NET applications that can be used to seed any database with initial data.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To get started with InzSeeder, you can either:
 
 1. Add the NuGet package to your project:
    ```bash
-   dotnet add package Inz.Seeder
+   dotnet add package InzSoftwares.NetSeeder
    ```
 
 2. Or clone this repository and explore the sample projects:
@@ -53,7 +53,7 @@ To get started with InzSeeder, you can either:
 Add the InzSeeder NuGet package to your project:
 
 ```bash
-dotnet add package Inz.Seeder
+dotnet add package InzSoftwares.NetSeeder
 ```
 
 ### 2. Create Your Data Models


### PR DESCRIPTION
- Renames the NuGet package ID from 'Inz.Seeder' to 'InzSoftwares.NetSeeder'.
- Updates the .csproj file with additional metadata including repository URL, copyright, and license information.
- Includes the LICENSE file in the NuGet package.
- Updates the publishing workflow and all README files to reflect the new package name.
- Removes the push trigger from the test workflow to avoid redundant runs. Tests will now only be executed on pull requests.
- Bumps the package version to 2.0.3.